### PR TITLE
Use `:network` modifier. Closes #2

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,7 +484,7 @@ pass in on $p_lan inet proto udp from any port 67
 # Allow access to the Internet by removing the comment.
 # This rule will also block access to our two other segments, the grown-ups LAN
 # and the children's LAN.
-# pass in on $p_lan to { ! 192.168.1.0/24 ! 192.168.2.0/24 }
+# pass in on $p_lan to { ! g_lan:network ! c_lan:network }
 
 # Always block DNS queries not addressed to our DNS server.
 block return in quick on $p_lan proto { udp tcp} to ! $p_lan port { 53 853 }

--- a/index.html
+++ b/index.html
@@ -484,7 +484,7 @@ pass in on $p_lan inet proto udp from any port 67
 # Allow access to the Internet by removing the comment.
 # This rule will also block access to our two other segments, the grown-ups LAN
 # and the children's LAN.
-# pass in on $p_lan to { ! g_lan:network ! c_lan:network }
+# pass in on $p_lan to { ! $g_lan:network ! $c_lan:network }
 
 # Always block DNS queries not addressed to our DNS server.
 block return in quick on $p_lan proto { udp tcp} to ! $p_lan port { 53 853 }


### PR DESCRIPTION
The [`:network`](https://man.openbsd.org/pf.conf.5#:network) modifier will pick up the IP address range from `hostname.if`. Using this notation will prevent repetition of hard-coded IP address ranges.