### PR TITLE
Fix img src paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <article>
 <table>
     <tr>
-        <td><img src="/includes/img/openbsd-icon.png" alt="OpenBSD icon"></td>
+        <td><img src="/includes/img/openbsd-icon.webp" alt="OpenBSD icon"></td>
         <td>
             <h1 class="title">OpenBSD Router Guide</h1>
             <h4>Network segmenting firewall, DHCP, DNS with Unbound, domain blocking and much more<br>
@@ -127,7 +127,7 @@
 
 <p>I have build multiple solutions with the <a href="https://www.asrock.com/mb/Intel/Q1900DC-ITX/">ASRock Q1900DC-ITX</a> motherboard that comes with an Intel Quad-Core Celeron processor.</p>
 
-<p><img src="/includes/img/asrock-q1900dc-itx.png" alt="ASRock Q1900DC-ITX motherboard"></p>
+<p><img src="/includes/img/asrock-q1900dc-itx.webp" alt="ASRock Q1900DC-ITX motherboard"></p>
 
 <p>I'll admit, it's a pretty "crappy" motherboard, but it gets the job done and I have several builds that have run very solid for many years on gigabit networks with full saturation and the firewall, DNS, etc. working "overtime" and the CPU hardly breaks a sweat.</p>
 
@@ -137,13 +137,13 @@
 
 <p>I have also used the ASRock Q1900-ITX (it doesn't come with the DC-In Jack) combined with a PicoPSU.</p>
 
-<p><img src="/includes/img/picopsu.png" alt="PicoPSU power supply"></p>
+<p><img src="/includes/img/picopsu.webp" alt="PicoPSU power supply"></p>
 
 <p>You can find different brands and versions of the PicoPSU, some are better quality than others. I have two different brands, the original and a cheaper knockoff, both performs very well and they save quite a bit of power contrary to running with a normal power supply.</p>
 
 <p>Last, I am using a cheap Intel knockoff quad port NIC found on Ebay like this one:</p>
 
-<p><img src="/includes/img/intel-quad-nic.png" alt="Intel Quad NIC"></p>
+<p><img src="/includes/img/intel-quad-nic.webp" alt="Intel Quad NIC"></p>
 
 <p>I know it is better to use quality hardware, especially on a network that you care about, but this tutorial is about how you can get away with using fairly cheep hardware and still get an extremely useful product that will continue to serve you well for many years - at least that is my experience.</p>
 


### PR DESCRIPTION
https://openbsdrouterguide.net/ doesn't show any images because their `src` is wrong pointing at `.png` files where only `.webp` files are available. This commit changes the `src` attributes in the HTML source to point to the available images.